### PR TITLE
code now matches docs and ensures only one builder is active at a time

### DIFF
--- a/examples/image.rs
+++ b/examples/image.rs
@@ -2,7 +2,7 @@ use wkhtmltopdf::*;
 
 fn main() {
     env_logger::init();
-    let image_app = ImageApplication::new().expect("Failed to init image application");
+    let mut image_app = ImageApplication::new().expect("Failed to init image application");
 
     {
         let mut out = image_app

--- a/examples/lowlevel.rs
+++ b/examples/lowlevel.rs
@@ -5,7 +5,7 @@ use wkhtmltopdf::*;
 
 fn main() {
     env_logger::init();
-    let pdf_app = PdfApplication::new().expect("Failed to init PDF application");
+    let mut pdf_app = PdfApplication::new().expect("Failed to init PDF application");
 
     let html = r#"
         <html><body>

--- a/examples/lowlevel.rs
+++ b/examples/lowlevel.rs
@@ -1,4 +1,3 @@
-
 use std::fs::File;
 use wkhtmltopdf::Orientation;
 use wkhtmltopdf::*;

--- a/examples/lowlevel.rs
+++ b/examples/lowlevel.rs
@@ -1,4 +1,4 @@
-use env_logger;
+
 use std::fs::File;
 use wkhtmltopdf::Orientation;
 use wkhtmltopdf::*;
@@ -45,7 +45,7 @@ fn main() {
     })));
 
     // Add an html object and convert
-    c.add_html_object(os, &html);
+    c.add_html_object(os, html);
     let mut pdfout = c.convert().expect("failed to convert");
 
     // let mut pdfout = pdfout;

--- a/examples/pdf.rs
+++ b/examples/pdf.rs
@@ -1,4 +1,4 @@
-use env_logger;
+
 
 use wkhtmltopdf::*;
 
@@ -27,7 +27,7 @@ fn main() {
 
     {
         let mut pdfout1 = builder1
-            .build_from_html(&html)
+            .build_from_html(html)
             .expect("failed to build pdf");
 
         let _ = pdfout1.save("basic.pdf").expect("failed to save basic.pdf");

--- a/examples/pdf.rs
+++ b/examples/pdf.rs
@@ -4,7 +4,7 @@ use wkhtmltopdf::*;
 
 fn main() {
     env_logger::init();
-    let pdf_app = PdfApplication::new().expect("Failed to init PDF application");
+    let mut pdf_app = PdfApplication::new().expect("Failed to init PDF application");
 
     let html = r#"
       <html><body>

--- a/examples/pdf.rs
+++ b/examples/pdf.rs
@@ -1,5 +1,3 @@
-
-
 use wkhtmltopdf::*;
 
 fn main() {
@@ -26,9 +24,7 @@ fn main() {
         .title("Rust Website");
 
     {
-        let mut pdfout1 = builder1
-            .build_from_html(html)
-            .expect("failed to build pdf");
+        let mut pdfout1 = builder1.build_from_html(html).expect("failed to build pdf");
 
         let _ = pdfout1.save("basic.pdf").expect("failed to save basic.pdf");
         println!("PDF saved as basic.pdf");

--- a/src/image/lowlevel.rs
+++ b/src/image/lowlevel.rs
@@ -285,7 +285,7 @@ unsafe extern "C" fn finished_callback(converter: *mut wkhtmltoimage_converter, 
         // call and remove this converter's FINISHED_CALLBACK
         let mut callbacks = FINISHED_CALLBACKS.lock().unwrap();
         if let Some(mut cb) = callbacks.remove(&id) {
-            cb(val as i32);
+            cb(val);
         }
     }
 }

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -194,7 +194,7 @@ impl ImageBuilder {
     pub fn build_from_url<'a, 'b>(&'a mut self, url: &Url) -> Result<ImageOutput<'b>> {
         let mut global = self.global_settings()?;
         unsafe {
-            global.set("in", &*url.as_str())?;
+            global.set("in", url.as_str())?;
         }
         let converter = global.create_converter(None);
         converter.convert()
@@ -266,8 +266,8 @@ impl ImageBuilder {
     /// Use the relevant settings to construct a low-level instance of `ImageGlobalSettings`
     pub fn global_settings(&self) -> Result<ImageGlobalSettings> {
         let mut global = ImageGlobalSettings::new()?;
-        for (ref name, ref val) in &self.gs {
-            unsafe { global.set(name, &val) }?;
+        for (name, val) in &self.gs {
+            unsafe { global.set(name, val) }?;
         }
         Ok(global)
     }

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -9,7 +9,7 @@
 //! ```no_run
 //! use wkhtmltopdf::*;
 //!
-//! let image_app = ImageApplication::new().expect("Failed to init image application");
+//! let mut image_app = ImageApplication::new().expect("Failed to init image application");
 //! let mut imageout = image_app.builder()
 //!     .format(ImageFormat::Png)
 //!     .build_from_path("input.html")
@@ -72,7 +72,7 @@ impl ImageApplication {
     /// This method borrows the `self` mutably to ensure only that one builder is active at a time which is a
     /// [basic limitation of wkhtmltoimage](https://github.com/wkhtmltoimage/wkhtmltoimage/issues/1711).
     /// Parallel execution is currently only possible by spawning multiple processes.
-    pub fn builder(&self) -> ImageBuilder {
+    pub fn builder(&mut self) -> ImageBuilder {
         ImageBuilder { gs: HashMap::new() }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ mod tests {
     fn one_test_to_rule_them_all() {
         // Has to be a single test because PdfApplication can only be initialized once and is !Sync/!Send
         let _ = env_logger::init();
-        let pdf_app = PdfApplication::new().expect("Failed to init PDF Application");
+        let mut pdf_app = PdfApplication::new().expect("Failed to init PDF Application");
 
         {
             // Test building PDF from HTML
@@ -31,7 +31,7 @@ mod tests {
             assert!(res.is_ok(), "{}", res.unwrap_err());
         }
 
-        let image_app = ImageApplication::new().expect("Failed to init image Application");
+        let mut image_app = ImageApplication::new().expect("Failed to init image Application");
 
         {
             // Test building image from file

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ mod tests {
     #[test]
     fn one_test_to_rule_them_all() {
         // Has to be a single test because PdfApplication can only be initialized once and is !Sync/!Send
-        let _ = env_logger::init();
+        env_logger::init();
         let mut pdf_app = PdfApplication::new().expect("Failed to init PDF Application");
 
         {

--- a/src/pdf/lowlevel.rs
+++ b/src/pdf/lowlevel.rs
@@ -391,7 +391,7 @@ unsafe extern "C" fn finished_callback(converter: *mut wkhtmltopdf_converter, va
         // call and remove this converter's FINISHED_CALLBACK
         let mut callbacks = FINISHED_CALLBACKS.lock().unwrap();
         if let Some(mut cb) = callbacks.remove(&id) {
-            cb(val as i32);
+            cb(val);
         }
     }
 }

--- a/src/pdf/mod.rs
+++ b/src/pdf/mod.rs
@@ -10,7 +10,7 @@
 //! use wkhtmltopdf::*;
 //!
 //! let html = r#"<html><body><div>foo</div></body></html>"#;
-//! let pdf_app = PdfApplication::new().expect("Failed to init PDF application");
+//! let mut pdf_app = PdfApplication::new().expect("Failed to init PDF application");
 //! let mut pdfout = pdf_app.builder()
 //!     .orientation(Orientation::Landscape)
 //!     .margin(Size::Inches(2))
@@ -182,7 +182,7 @@ impl PdfApplication {
     /// This method borrows the `self` mutably to ensure only that one builder is active at a time which is a
     /// [basic limitation of wkhtmltopdf](https://github.com/wkhtmltopdf/wkhtmltopdf/issues/1711).
     /// Parallel execution is currently only possible by spawning multiple processes.
-    pub fn builder(&self) -> PdfBuilder {
+    pub fn builder(&mut self) -> PdfBuilder {
         PdfBuilder {
             gs: HashMap::new(),
             os: HashMap::new(),

--- a/src/pdf/mod.rs
+++ b/src/pdf/mod.rs
@@ -371,8 +371,8 @@ impl PdfBuilder {
     /// Use the relevant settings to construct a low-level instance of `PdfGlobalSettings`
     pub fn global_settings(&self) -> Result<PdfGlobalSettings> {
         let mut global = PdfGlobalSettings::new()?;
-        for (ref name, ref val) in &self.gs {
-            unsafe { global.set(name, &val) }?;
+        for (name, val) in &self.gs {
+            unsafe { global.set(name, val) }?;
         }
         Ok(global)
     }
@@ -380,8 +380,8 @@ impl PdfBuilder {
     /// Use the relevant settings to construct a low-level instance of `PdfObjectSettings`
     pub fn object_settings(&self) -> Result<PdfObjectSettings> {
         let mut object = PdfObjectSettings::new();
-        for (ref name, ref val) in &self.os {
-            unsafe { object.set(name, &val) }?;
+        for (name, val) in &self.os {
+            unsafe { object.set(name, val) }?;
         }
         Ok(object)
     }


### PR DESCRIPTION
As discovered by @cyqsimon in #17 there a mismatch between the documentation and code in that the builders are not using mut. This PR introduces mut to match the documentation. This PR still needs a test to prove or disprove if the documentation is in fact correct.